### PR TITLE
This commit mostly achieves a number of objectives.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,9 @@
 apply plugin: 'java'
+//  Uncomment to view deprecation warnings. 
+//  compileJava {
+//    options.compilerArgs << '-Xlint:deprecation'
+//    options.compilerArgs << '-Xlint:unchecked'
+//  }
 apply plugin: 'idea'
 
 sourceCompatibility = 1.8
@@ -25,6 +30,8 @@ repositories {
         //url 'http://nexus.theyeticave.net/content/repositories/pub_releases/'
         url 'https://jitpack.io'
     }
+    // For 1.12, adding NMS package; Spigot's BuildTools will do a local Maven install. Let's look there.
+    mavenLocal()
 }
 
 dependencies {
@@ -34,6 +41,7 @@ dependencies {
 
     compile project(':RecipeManagerCommon')
     compile "org.bukkit:bukkit:1.12-R0.1-SNAPSHOT"
+    compile "org.spigotmc:spigot:1.12-R0.1-SNAPSHOT"
     //compile "net.milkbowl.vault:VaultAPI:1.6"
     compile "com.github.MilkBowl:VaultAPI:master-SNAPSHOT"
     

--- a/src/main/java/haveric/recipeManager/RecipeManager.java
+++ b/src/main/java/haveric/recipeManager/RecipeManager.java
@@ -13,6 +13,7 @@ import haveric.recipeManager.flag.FlagLoader;
 import haveric.recipeManager.messages.MessageSender;
 import haveric.recipeManager.messages.Messages;
 import haveric.recipeManager.metrics.Metrics;
+import haveric.recipeManager.tools.Version;
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.permission.Permission;
 import org.bukkit.Bukkit;
@@ -175,7 +176,13 @@ public class RecipeManager extends JavaPlugin {
             }
 
             if (!firstTime && !Settings.getInstance().getClearRecipes()) {
-                Vanilla.restoreAllButSpecialRecipes();
+                if (!Version.has1_12Support()) {
+                    Vanilla.restoreAllButSpecialRecipes();
+                } else {
+                    try {
+                        Bukkit.getServer().reloadData();
+                    } catch (NullPointerException npe) { /* Test Framework hates this */ }
+                }
                 Recipes.getInstance().index.putAll(Vanilla.initialRecipes);
             }
         }

--- a/src/main/java/haveric/recipeManager/RecipeManager.java
+++ b/src/main/java/haveric/recipeManager/RecipeManager.java
@@ -178,12 +178,13 @@ public class RecipeManager extends JavaPlugin {
             if (!firstTime && !Settings.getInstance().getClearRecipes()) {
                 if (!Version.has1_12Support()) {
                     Vanilla.restoreAllButSpecialRecipes();
+                    Recipes.getInstance().index.putAll(Vanilla.initialRecipes);
                 } else {
                     try {
-                        Bukkit.getServer().reloadData();
+                        Bukkit.getServer().resetRecipes();
+                        Vanilla.init();
                     } catch (NullPointerException npe) { /* Test Framework hates this */ }
                 }
-                Recipes.getInstance().index.putAll(Vanilla.initialRecipes);
             }
         }
 

--- a/src/main/java/haveric/recipeManager/RecipeManager.java
+++ b/src/main/java/haveric/recipeManager/RecipeManager.java
@@ -180,10 +180,9 @@ public class RecipeManager extends JavaPlugin {
                     Vanilla.restoreAllButSpecialRecipes();
                     Recipes.getInstance().index.putAll(Vanilla.initialRecipes);
                 } else {
-                    try {
-                        Bukkit.getServer().resetRecipes();
-                        Vanilla.init();
-                    } catch (NullPointerException npe) { /* Test Framework hates this */ }
+                    Vanilla.removeCustomRecipes();
+                    // Basically does server recipe reset and vanilla re-init, but also
+                    // tries to save any other recipes.
                 }
             }
         }

--- a/src/main/java/haveric/recipeManager/RecipeRegistrator.java
+++ b/src/main/java/haveric/recipeManager/RecipeRegistrator.java
@@ -102,15 +102,6 @@ public class RecipeRegistrator {
 
         RecipeBooks.getInstance().reloadAfterRecipes(sender); // (re)create recipe books for recipes
         
-        // TODO: Force-remap / reload Achievements? How do we keep achievements in sync from changes here?
-        if (Version.has1_12Support()) {
-            try {
-                //Bukkit.getServer().reloadData(); remove for now...
-            } catch (NullPointerException npe) {
-                // During test running.
-            }
-        }
-
         MessageSender.getInstance().send(sender, String.format("All done in %.3f seconds, %d recipes processed.", ((System.currentTimeMillis() - start) / 1000.0), processed));
     }
 

--- a/src/main/java/haveric/recipeManager/Recipes.java
+++ b/src/main/java/haveric/recipeManager/Recipes.java
@@ -5,6 +5,7 @@ import haveric.recipeManager.flag.args.Args;
 import haveric.recipeManager.flag.FlagType;
 import haveric.recipeManager.recipes.*;
 import haveric.recipeManager.tools.Tools;
+import haveric.recipeManager.tools.Version;
 import haveric.recipeManagerCommon.RMCChatColor;
 import haveric.recipeManagerCommon.recipes.RMCRecipeInfo;
 import haveric.recipeManagerCommon.recipes.RMCRecipeInfo.RecipeOwner;
@@ -333,6 +334,12 @@ public class Recipes {
             recipe.setBukkitRecipe(Vanilla.removeCustomRecipe(recipe));
         }
 
+        // For 1.12, we don't actually _remove_ the recipe. So, we nullify the Bukkit binding to 
+        //  ensure the RM recipe is added.
+        if (Version.has1_12Support() && recipe.hasFlag(FlagType.OVERRIDE)) {
+            recipe.setBukkitRecipe(null);
+        }
+
         // Add to server if applicable
         if (!recipe.hasFlag(FlagType.REMOVE)) {
             Recipe bukkitRecipe = recipe.getBukkitRecipe(false);
@@ -371,7 +378,9 @@ public class Recipes {
      * @return removed recipe or null if not found
      */
     public Recipe removeRecipe(BaseRecipe recipe) {
-        if (recipe.hasFlag(FlagType.REMOVE) || recipe.hasFlag(FlagType.OVERRIDE)) {
+        // In 1.12, adding the RM recipe is handled elsewhere; we just need to remove indexing here.
+        //  if we did try to add, we'd get a fatal error and this whole mess would fail.
+        if (!Version.has1_12Support() && (recipe.hasFlag(FlagType.REMOVE) || recipe.hasFlag(FlagType.OVERRIDE))) {
             Bukkit.getServer().addRecipe(recipe.getBukkitRecipe(false));
         }
 

--- a/src/main/java/haveric/recipeManager/Vanilla.java
+++ b/src/main/java/haveric/recipeManager/Vanilla.java
@@ -484,7 +484,7 @@ public class Vanilla {
 
         if (Version.has1_12Support()) {
             try {
-                Bukkit.getServer().reloadData();
+                Bukkit.getServer().resetRecipes();
             } catch (NullPointerException npe) { /* Tests hate this */ }
 
             for (Recipe newRecipe : originalRecipes) {

--- a/src/main/java/haveric/recipeManager/commands/ReloadCommand.java
+++ b/src/main/java/haveric/recipeManager/commands/ReloadCommand.java
@@ -1,13 +1,96 @@
 package haveric.recipeManager.commands;
 
 import haveric.recipeManager.RecipeManager;
+import haveric.recipeManager.messages.MessageSender;
+import haveric.recipeManager.tools.Version;
 
+import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.conversations.Conversable;
+import org.bukkit.conversations.ConversationAbandonedEvent;
+import org.bukkit.conversations.ConversationAbandonedListener;
+import org.bukkit.conversations.ConversationContext;
+import org.bukkit.conversations.ConversationFactory;
+import org.bukkit.conversations.MessagePrompt;
+import org.bukkit.conversations.Prompt;
+import org.bukkit.conversations.StringPrompt;
 
 public class ReloadCommand implements CommandExecutor {
+    ConversationFactory reloadConversation = null;
+    
+    public ReloadCommand() {
+        reloadConversation = new ConversationFactory(RecipeManager.getPlugin()).withLocalEcho(true)
+                .withModality(false).withTimeout(60).addConversationAbandonedListener(new ConversationAbandonedListener() {
+                    @Override
+                    public void conversationAbandoned(ConversationAbandonedEvent abandonedEvent) {
+                        if (!abandonedEvent.gracefulExit()) {
+                            abandonedEvent.getContext().getForWhom().sendRawMessage("Reload cancelled due to timeout.");
+                        }
+                    }
+                    
+                } ).withFirstPrompt(new StringPrompt() {
+                    @Override
+                    public String getPromptText(ConversationContext context) {
+                        return "Reloading in MC 1.12 or newer is not guaranteed to function " +
+                                "and may disrupt other plugins that also manage recipes.\n " +
+                                "Are you sure you want to continue? Type \"yes\" to continue " +
+                                "and anything else to cancel.";
+                                
+                    }
+
+                    @Override
+                    public Prompt acceptInput(ConversationContext context, String input) {
+                        String cleanseInput = input.toLowerCase().trim();
+                        if (cleanseInput.equals("yes")) {
+                            return new MessagePrompt() {
+
+                                @Override
+                                public String getPromptText(ConversationContext context) {
+                                    return "As requested, performing reload.";
+                                }
+
+                                @Override
+                                protected Prompt getNextPrompt(ConversationContext context) {
+                                    Conversable whom = context.getForWhom();
+                                    if (whom instanceof CommandSender) {
+                                        RecipeManager.getPlugin().reload((CommandSender) whom, false, false);
+                                    } else {
+                                        RecipeManager.getPlugin().reload(Bukkit.getConsoleSender(), false, false);
+                                    }
+                                    return Prompt.END_OF_CONVERSATION;
+                                }
+                                
+                            };
+                        } else {
+                            return new MessagePrompt() {
+
+                                @Override
+                                public String getPromptText(ConversationContext context) {
+                                    return "As requested, cancelling reload.";
+                                }
+
+                                @Override
+                                protected Prompt getNextPrompt(ConversationContext context) {
+                                    return Prompt.END_OF_CONVERSATION;
+                                }
+                                
+                            };
+                        }
+                    }
+                });
+    }
+    
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (Version.has1_12Support()) {
+            if (sender instanceof Conversable) {
+                reloadConversation.buildConversation( (Conversable) sender).begin();
+                return true;
+            } else {
+                MessageSender.getInstance().sendAndLog(sender, "WARNING: reload may cause instability or loss of recipe function in MC 1.12 or newer!");
+            }
+        }
         RecipeManager.getPlugin().reload(sender, false, false);
 
         return true;

--- a/src/main/java/haveric/recipeManager/recipes/ConditionEvaluator.java
+++ b/src/main/java/haveric/recipeManager/recipes/ConditionEvaluator.java
@@ -6,9 +6,13 @@ import haveric.recipeManager.RecipeRegistrator;
 import haveric.recipeManager.Settings;
 import haveric.recipeManager.flag.FlagType;
 import haveric.recipeManager.flag.flags.FlagOverride;
+import haveric.recipeManager.tools.ToolsRecipeV1_12;
+import haveric.recipeManager.tools.Version;
 import haveric.recipeManagerCommon.recipes.RMCRecipeInfo;
+import haveric.recipeManagerCommon.recipes.RMCRecipeInfo.RecipeOwner;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.Recipe;
 
 import java.util.Map;
 
@@ -88,6 +92,25 @@ public class ConditionEvaluator {
     }
 
     private RMCRecipeInfo getRecipeFromMap(BaseRecipe recipe, Map<BaseRecipe, RMCRecipeInfo> map) {
+        if (Version.has1_12Support()) {
+            for (Map.Entry<BaseRecipe, RMCRecipeInfo> entry : map.entrySet()) {
+                // Let's only use this special logic for recipes where RMCRecipeInfo has the bukkit pointer.
+                if (entry.getValue().getOwner() == RecipeOwner.MINECRAFT && !entry.getKey().isVanillaSpecialRecipe()) {
+                    Recipe bukkit = entry.getKey().getBukkitRecipe(true);
+                    if (ToolsRecipeV1_12.matches(recipe, bukkit)) {
+                        return entry.getValue();
+                    } else if (recipe instanceof CraftRecipe) {
+                        CraftRecipe cr = (CraftRecipe) recipe;
+                        cr.setMirrorShape(true);
+
+                        if (ToolsRecipeV1_12.matches(cr, bukkit)) {
+                            return entry.getValue();
+                        }
+                    }
+                }
+            }
+        }
+
         RMCRecipeInfo info = map.get(recipe);
 
         if (info == null && recipe instanceof CraftRecipe) {

--- a/src/main/java/haveric/recipeManager/recipes/CraftRecipeParser.java
+++ b/src/main/java/haveric/recipeManager/recipes/CraftRecipeParser.java
@@ -88,7 +88,7 @@ public class CraftRecipeParser extends BaseRecipeParser {
 
         recipe.setIngredients(ingredients); // done with ingredients, set 'em
 
-        if (recipe.hasFlag(FlagType.REMOVE)) {
+        if (recipe.hasFlag(FlagType.REMOVE) && !Version.has1_12Support()) { // for mc1.12, matching requires outcome too...
             this.reader.nextLine(); // Skip the results line, if it exists
         } else {
             // get results

--- a/src/main/java/haveric/recipeManager/tools/RecipeIteratorV1_12.java
+++ b/src/main/java/haveric/recipeManager/tools/RecipeIteratorV1_12.java
@@ -1,0 +1,194 @@
+package haveric.recipeManager.tools;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.bukkit.inventory.Recipe;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.ShapelessRecipe;
+
+import haveric.recipeManager.messages.MessageSender;
+import haveric.recipeManager.recipes.BaseRecipe;
+import haveric.recipeManager.recipes.CombineRecipe;
+import haveric.recipeManager.recipes.CraftRecipe;
+import haveric.recipeManager.recipes.ItemResult;
+import haveric.recipeManager.recipes.SmeltRecipe;
+import net.minecraft.server.v1_12_R1.CraftingManager;
+import net.minecraft.server.v1_12_R1.IRecipe;
+import net.minecraft.server.v1_12_R1.ItemStack;
+import net.minecraft.server.v1_12_R1.MinecraftKey;
+import net.minecraft.server.v1_12_R1.RecipesFurnace;
+import net.minecraft.server.v1_12_R1.RegistryMaterials;
+import net.minecraft.server.v1_12_R1.ShapedRecipes;
+import net.minecraft.server.v1_12_R1.ShapelessRecipes;
+import net.minecraft.server.v1_12_R1.Items;
+import net.minecraft.server.v1_12_R1.NonNullList;
+import net.minecraft.server.v1_12_R1.RecipeItemStack;
+
+import org.bukkit.craftbukkit.v1_12_R1.inventory.CraftFurnaceRecipe;
+import org.bukkit.craftbukkit.v1_12_R1.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.v1_12_R1.inventory.RecipeIterator;
+
+public class RecipeIteratorV1_12 implements Iterator<Recipe> {
+    private Iterator<IRecipe> recipes = null;
+
+    private Iterator<ItemStack> smeltingCustom = null;
+    private List<ItemStack> recipeSmeltingCustom = new LinkedList<>();
+
+    private Iterator<ItemStack> smeltingVanilla = null;
+    private List<ItemStack> recipeSmeltingVanilla = new LinkedList<>();
+
+    enum RemoveFrom {
+        RECIPES, CUSTOM, VANILLA
+    }
+
+    RemoveFrom removeFrom = null;
+    IRecipe removeRecipe = null;
+    ItemStack removeItem = null;
+
+    public RecipeIteratorV1_12(Iterator<Recipe> backing) {
+        if (backing instanceof RecipeIterator) {
+            recipes = CraftingManager.recipes.iterator();
+            smeltingCustom = RecipesFurnace.getInstance().customRecipes.keySet().iterator();
+            smeltingVanilla = RecipesFurnace.getInstance().recipes.keySet().iterator();
+        } else {
+            throw new IllegalArgumentException("This version is not supported.");
+        }
+    }
+
+    /**
+     * If nothing more is accessible, finalize any removals before informing caller of nothing new.
+     */
+    @Override
+    public boolean hasNext() {
+        boolean next = recipes.hasNext() || smeltingCustom.hasNext() || smeltingVanilla.hasNext();
+        if (!next) {
+            finish();
+        }
+        return next;
+    }
+
+    @Override
+    public Recipe next() {
+        if (recipes.hasNext()) {
+            removeFrom = RemoveFrom.RECIPES;
+            removeRecipe = recipes.next();
+            return removeRecipe.toBukkitRecipe();
+        } else {
+            ItemStack item;
+            if (smeltingCustom.hasNext()) {
+                removeFrom = RemoveFrom.CUSTOM;
+                item = smeltingCustom.next();
+            } else {
+                removeFrom = RemoveFrom.VANILLA;
+                item = smeltingVanilla.next();
+            }
+            removeItem = item;
+
+            CraftItemStack stack = CraftItemStack.asCraftMirror(RecipesFurnace.getInstance().getResult(item));
+
+            return new CraftFurnaceRecipe(stack, CraftItemStack.asCraftMirror(item));
+        }
+    }
+
+    /**
+     * Backing list is now immutable in 1.12.
+     * 
+     * We have two modes of operation. For recipes, we don't remove, we simply replace them with dummy data
+     * that can never be matched. In this way, ID ordering is preserved and we avoid any unpleasantness with 
+     * the fact that the Client and Server both assume recipes have a specific ID order sequence to them.
+     *
+     * For Smelting, we register the requests to remove, and perform those removals when we are done iterating
+     * or are requested to finalize. 
+     */
+    public void remove() {
+        if (removeFrom == null) {
+            throw new IllegalStateException();
+        }
+        switch (removeFrom) {
+        case RECIPES:
+            try {
+                Field keyF = removeRecipe.getClass().getField("key");
+                MinecraftKey key = (MinecraftKey) keyF.get(removeRecipe);
+                if (removeRecipe instanceof ShapedRecipes) {
+                    ShapedRecipes shaped = (ShapedRecipes) removeRecipe;
+                    Field widthF = stripPrivateFinal(ShapedRecipes.class, "width");
+                    Field heightF = stripPrivateFinal(ShapedRecipes.class, "height");
+                    Field itemsF = stripPrivateFinal(ShapedRecipes.class, "items");
+                    Field resultF = stripPrivateFinal(ShapedRecipes.class, "result");
+
+                    // now for the _real_ fun, modifying an unmodifiable recipe.
+                    // So for shaped recipes, my thought is just to replace the ItemStack with something
+                    // nonsensical, set height and width to 1, and hope it isn't cached in too many places.
+                    // Oh, and set result to air.
+                    widthF.setInt(shaped, 1);
+                    heightF.setInt(shaped, 1);
+                    resultF.set(shaped, new ItemStack(Items.a, 1));
+                    itemsF.set(shaped, NonNullList.a(1, RecipeItemStack.a(Items.a)));
+                } else if (removeRecipe instanceof ShapelessRecipes) {
+                    ShapelessRecipes shapeless = (ShapelessRecipes) removeRecipe;
+                    Field ingredientsF = stripPrivateFinal(ShapelessRecipes.class, "ingredients");
+                    Field resultF = stripPrivateFinal(ShapelessRecipes.class, "result");
+
+                    resultF.set(shapeless, new ItemStack(Items.a, 1));
+                    ingredientsF.set(shapeless, NonNullList.a(1, RecipeItemStack.a(Items.a)));                            
+                } else {
+                    throw new IllegalStateException("You cannot replace a grid recipe with a " + removeRecipe.getClass().getName() + " recipe!");
+                }
+            } catch (Exception e) {
+                MessageSender.getInstance().error(null, e, "NMS failure for v1.12 support during grid recipe removal");
+            }
+            break;
+        case CUSTOM:
+            recipeSmeltingCustom.add(removeItem);
+            break;
+        case VANILLA:
+            recipeSmeltingVanilla.add(removeItem);
+        }
+    }
+
+    private Field stripPrivateFinal(Class clazz, String field) throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
+        Field fieldF = clazz.getDeclaredField(field);
+        fieldF.setAccessible(true);
+        // Remove final modifier
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(fieldF, fieldF.getModifiers() & ~Modifier.FINAL);
+        return fieldF;
+    }
+    
+    /**
+     * This is the companion to remove(), and effectuates removals of furnace recipes. It is called automatically when 
+     * the end of the iterator is reached; in other settings, call it manually.
+     */
+    public void finish() {
+        if (!recipeSmeltingCustom.isEmpty()) {
+            RecipesFurnace furnaces = RecipesFurnace.getInstance();
+            recipeSmeltingCustom.forEach(item -> {
+                furnaces.customRecipes.remove(item);
+                furnaces.customExperience.remove(item);
+            });
+        }
+        if (!recipeSmeltingVanilla.isEmpty()) {
+            RecipesFurnace furnaces = RecipesFurnace.getInstance();
+            try {
+                Field experienceF = RecipesFurnace.class.getDeclaredField("experience");
+                experienceF.setAccessible(true);
+                @SuppressWarnings("unchecked")
+                Map<ItemStack, Float> experience = (Map<ItemStack, Float>) experienceF.get(furnaces);
+                recipeSmeltingVanilla.forEach(item -> {
+                    furnaces.recipes.remove(item);
+                    experience.remove(item);
+                });
+            } catch (Exception e) {
+                MessageSender.getInstance().error(null, e, "NMS failure for v1.12 support during vanilla smelting removal");
+            }
+
+        }
+    }
+}

--- a/src/main/java/haveric/recipeManager/tools/RecipeIteratorV1_12.java
+++ b/src/main/java/haveric/recipeManager/tools/RecipeIteratorV1_12.java
@@ -27,6 +27,8 @@ import net.minecraft.server.v1_12_R1.RegistryMaterials;
 import net.minecraft.server.v1_12_R1.ShapedRecipes;
 import net.minecraft.server.v1_12_R1.ShapelessRecipes;
 import net.minecraft.server.v1_12_R1.Items;
+import net.minecraft.server.v1_12_R1.ItemSnow;
+import net.minecraft.server.v1_12_R1.Blocks;
 import net.minecraft.server.v1_12_R1.NonNullList;
 import net.minecraft.server.v1_12_R1.RecipeItemStack;
 
@@ -129,14 +131,14 @@ public class RecipeIteratorV1_12 implements Iterator<Recipe> {
                     widthF.setInt(shaped, 1);
                     heightF.setInt(shaped, 1);
                     resultF.set(shaped, new ItemStack(Items.a, 1));
-                    itemsF.set(shaped, NonNullList.a(1, RecipeItemStack.a(Items.a)));
+                    itemsF.set(shaped, NonNullList.a(1, RecipeItemStack.a(new ItemStack[] {new ItemStack(new ItemSnow(Blocks.SNOW_LAYER), 1, 32767, false)})));
                 } else if (removeRecipe instanceof ShapelessRecipes) {
                     ShapelessRecipes shapeless = (ShapelessRecipes) removeRecipe;
                     Field ingredientsF = stripPrivateFinal(ShapelessRecipes.class, "ingredients");
                     Field resultF = stripPrivateFinal(ShapelessRecipes.class, "result");
 
                     resultF.set(shapeless, new ItemStack(Items.a, 1));
-                    ingredientsF.set(shapeless, NonNullList.a(1, RecipeItemStack.a(Items.a)));                            
+                    ingredientsF.set(shapeless, NonNullList.a(1, RecipeItemStack.a(new ItemStack[] {new ItemStack(new ItemSnow(Blocks.SNOW_LAYER), 1, 32767, false)})));
                 } else {
                     throw new IllegalStateException("You cannot replace a grid recipe with a " + removeRecipe.getClass().getName() + " recipe!");
                 }

--- a/src/main/java/haveric/recipeManager/tools/ToolsRecipeV1_12.java
+++ b/src/main/java/haveric/recipeManager/tools/ToolsRecipeV1_12.java
@@ -1,0 +1,176 @@
+package haveric.recipeManager.tools;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.logging.Level;
+
+import org.bukkit.Material;
+import org.bukkit.craftbukkit.v1_12_R1.inventory.CraftFurnaceRecipe;
+import org.bukkit.craftbukkit.v1_12_R1.inventory.CraftShapedRecipe;
+import org.bukkit.craftbukkit.v1_12_R1.inventory.CraftShapelessRecipe;
+import org.bukkit.inventory.Recipe;
+
+import haveric.recipeManager.RecipeManager;
+import haveric.recipeManager.Vanilla;
+import haveric.recipeManager.messages.MessageSender;
+import haveric.recipeManager.recipes.BaseRecipe;
+import haveric.recipeManager.recipes.CombineRecipe;
+import haveric.recipeManager.recipes.CraftRecipe;
+import haveric.recipeManager.recipes.SmeltRecipe;
+import net.minecraft.server.v1_12_R1.ItemStack;
+import net.minecraft.server.v1_12_R1.NonNullList;
+import net.minecraft.server.v1_12_R1.RecipeItemStack;
+import net.minecraft.server.v1_12_R1.ShapedRecipes;
+import net.minecraft.server.v1_12_R1.ShapelessRecipes;
+
+public class ToolsRecipeV1_12 {
+    /**
+     * Minecraft v1.12 NMS solution for matching if a RM recipe is already represented by an MC recipe.
+     *
+     * Basically duplicates the "internal" matching code.
+     **/
+    public static boolean matches(BaseRecipe baseRecipe, Recipe bukkitRecipe) {
+
+        if (bukkitRecipe instanceof CraftFurnaceRecipe) {
+            CraftFurnaceRecipe furnaceRecipe = (CraftFurnaceRecipe) bukkitRecipe;
+            if (baseRecipe instanceof SmeltRecipe) {
+                SmeltRecipe furnaceBase = (SmeltRecipe) baseRecipe;
+                // recipes are indexed by input, not result. So, if you overlap on input we don't care about output in terms of
+                // the server's understanding of recipes.
+                return furnaceBase.getIngredient().getType() == furnaceRecipe.getInput().getType()
+                        && (furnaceBase.getIngredient().getDurability() == Vanilla.DATA_WILDCARD || 
+                            furnaceRecipe.getInput().getDurability() == Vanilla.DATA_WILDCARD ||
+                            furnaceBase.getIngredient().getDurability() == furnaceRecipe.getInput().getDurability());
+            }
+            return false;
+        } else if (bukkitRecipe instanceof CraftShapedRecipe) {
+            CraftShapedRecipe shapedRecipe = (CraftShapedRecipe) bukkitRecipe;
+            if (baseRecipe instanceof CraftRecipe) {
+                CraftRecipe craftBase = (CraftRecipe) baseRecipe;
+
+                // Shortcut; if recipes don't have same geometry, not the same.
+                if (craftBase.getWidth() != shapedRecipe.getShape()[0].length()
+                        || craftBase.getHeight() != shapedRecipe.getShape().length) {
+                    return false;
+                }
+
+                // No such luck, but we do know geometry is the same and that is useful.
+                // roughly, we want to test, for each unique item type in the recipe, test it
+                // against every variation (until first successful match) of item types
+                // hidden by bukkit within the recipe definition.
+
+                try {
+                    Field recipeF = CraftShapedRecipe.class.getDeclaredField("recipe"); // pointer to MC recipe.
+                    recipeF.setAccessible(true);
+                    ShapedRecipes recipe = (ShapedRecipes) recipeF.get(shapedRecipe);
+
+                    Field itemsF = ShapedRecipes.class.getDeclaredField("items"); // pointer to _full_ list of items, hidden by Bukkit.
+                    itemsF.setAccessible(true);
+                    NonNullList<RecipeItemStack> items = (NonNullList<RecipeItemStack>) itemsF.get(recipe);
+
+                    char c = 'a';
+                    int i = 0;
+                    org.bukkit.inventory.ItemStack[] baseItems = craftBase.getIngredients();
+                    for (RecipeItemStack list : items) {
+                        org.bukkit.inventory.ItemStack baseItem = baseItems[(i / craftBase.getWidth()) * 3
+                                + (i % craftBase.getWidth())];
+                        if (baseItem == null) {
+                            baseItem = new org.bukkit.inventory.ItemStack(Material.AIR);
+                        }
+                        if (list != null && list.choices.length > 0) {
+                            boolean match = false;
+                            for (ItemStack stack : list.choices) {
+                                org.bukkit.inventory.ItemStack bukkitItem = new org.bukkit.inventory.ItemStack(
+                                        org.bukkit.craftbukkit.v1_12_R1.util.CraftMagicNumbers
+                                                .getMaterial(stack.getItem()),
+                                        1, (short) stack.getData());
+                                if (bukkitItem.getType() == baseItem.getType()
+                                        && (baseItem.getDurability() == Vanilla.DATA_WILDCARD
+                                                || bukkitItem.getDurability() == Vanilla.DATA_WILDCARD
+                                                || baseItem.getDurability() == bukkitItem.getDurability())) {
+                                    match = true;
+                                    break; // we need find only one match from all items. Stop when we have.
+                                }
+                            }
+                            if (!match) {
+                                return false; // fast fail.
+                            }
+                        } else {
+                            if (baseItem.getType() != Material.AIR) {
+                                return false; // fast fail.
+                            }
+                        }
+                        c++;
+                        i++;
+                    }
+                    // if we made it through the whole list, and never failed to match, we have a match.
+                    return true;
+
+                } catch (Exception e) {
+                    MessageSender.getInstance().error(null, e, "Failed during craft recipe lookup");
+                }
+            }
+            return false;
+        } else if (bukkitRecipe instanceof CraftShapelessRecipe) {
+            CraftShapelessRecipe shapelessRecipe = (CraftShapelessRecipe) bukkitRecipe;
+            if (baseRecipe instanceof CombineRecipe) {
+                CombineRecipe combineBase = (CombineRecipe) baseRecipe;
+
+                // Shortcut; if recipes don't have same # of itemtypes, not the same.
+                if (combineBase.getIngredients().size() != shapelessRecipe.getIngredientList().size()) {
+                    return false;
+                }
+
+                // No such luck, but we do know item size is the same and that is useful.
+                // roughly, we want to test, for each unique item type in the recipe, test it
+                // against every variation (until first successful match) of item types
+                // hidden by bukkit within the recipe definition.
+
+                try {
+                    Field recipeF = CraftShapelessRecipe.class.getDeclaredField("recipe"); // pointer to MC recipe.
+                    recipeF.setAccessible(true);
+                    ShapelessRecipes recipe = (ShapelessRecipes) recipeF.get(shapelessRecipe);
+
+                    Field itemsF = ShapelessRecipes.class.getDeclaredField("ingredients"); // pointer to _full_ list of items, hidden by Bukkit.
+                    itemsF.setAccessible(true);
+                    NonNullList<RecipeItemStack> items = (NonNullList<RecipeItemStack>) itemsF.get(recipe);
+
+                    // from Bukkit / spigot...
+                    int i = 0;
+                    List<org.bukkit.inventory.ItemStack> baseItems = combineBase.getIngredients();
+                    for (RecipeItemStack list : items) {
+                        org.bukkit.inventory.ItemStack baseItem = baseItems.get(i);
+                        if (list != null && list.choices.length > 0) {
+                            boolean match = false;
+                            for (ItemStack stack : list.choices) {
+                                org.bukkit.inventory.ItemStack bukkitItem = new org.bukkit.inventory.ItemStack(
+                                        org.bukkit.craftbukkit.v1_12_R1.util.CraftMagicNumbers
+                                                .getMaterial(stack.getItem()),
+                                        1, (short) stack.getData());
+                                if (bukkitItem.getType() == baseItem.getType()
+                                        && (baseItem.getDurability() == Vanilla.DATA_WILDCARD
+                                                || bukkitItem.getDurability() == Vanilla.DATA_WILDCARD
+                                                || baseItem.getDurability() == bukkitItem.getDurability())) {
+                                    match = true;
+                                    break; // we need find only one match from all items. Stop when we have.
+                                }
+                            }
+                            if (!match) {
+                                return false; // fast fail.
+                            }
+                        }
+                        i++;
+                    }
+                    // if we made it through the whole list, and never failed to match, we have a match.
+                    return true;
+
+                } catch (Exception e) {
+                    MessageSender.getInstance().error(null, e, "Failed during combine recipe lookup");
+                }
+            }
+            return false;
+        }
+
+        return false;
+    }
+}

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -2,10 +2,12 @@
 This file will be automatically overwritten when a new version is installed.
 
 === v2.11.0 Coming Soon ===
-* Added basic 1.12 Support (Please check your removal recipes against a fresh /rmextract as some have changed)
+* Added 1.12 Support (Please check your removal recipes against a fresh /rmextract as some have changed)
 * Fixed Sweeping Edge enchantment alias (again)
 * Fixed errors on shutdown
 * @Summon: Added support for invulnerable and noai (disabling ai)
+* To avoid "recipe not found, removing" errors and subsequent loss of advancement connections to managed recipes, give them all names. (e.g. craft <name>)
+** This is especially true for @override's, but is also true if you intend to leverage advancements.
 
 === v2.10.0 ===
 * New Flag: @MonsterSpawner (Requires Bukkit/Spigot build of 1/10/2017 or newer)


### PR DESCRIPTION
First and foremost, it introduces full 1.12 support for RecipeManager
recipe control. It achieves this through the introduction of two NMS
support classes, one to handle recipe matching for 1.12, and another to
support recipe iteration and removal for 1.12.

In Minecraft 1.12, due to advancements, Recipes have been significantly
reworked. The exact ordering of recipes is now important; specifically,
the vanilla recipe exact ordering is critical. So, the new 1.12 support
throughout RecipeManager, and especially the NMS sections, allow for
recipe "removal" simply through suppression. The recipes are modified
in-place with versions that will never match during crafting; ordering,
however, is preserved so Client-side advancements are less harmed by the
transition.

Note however, that if you do remove a recipe, clientside advancements
may have some artifacts involved when the player attempts to "pick" that
recipe from their recipe books once unlocked.

Additionally, if you replace a recipe, advancements for that recipe will
not work in the future; however, impairment will be restricted to those
recipes alone.

Future efforts might be necessary to better preserve advancements; for
instance, replace could be done "in-place" using an expansion of the
techniques used in RecipeIteratorV1_12. Removals could be similarly
hooked, suppressed by RecipeManager and otherwise untouched in the list.

I'll be exploring those options next.

Pending that, future efforts may be required to add new methods to hook
into advancements and inform the client of recipe removal. For now, this
seeks to split the difference, and allow largely backwards compatible
recipe manipulation including full support for Minecraft 1.12.

Known Issues:

* Reload does not yet work.
* Recipes from advancements normally connected to vanilla recipes removed or overridden will be lost on subsequent starts.

Thanks to Haveric for brainstorming and continued support of
RecipeManager and md_5 for the comment pointing to
necessity of preserving total ordering.