### PR TITLE
This addresses shapeless recipe issues.

### DIFF
--- a/src/main/java/haveric/recipeManager/tools/RecipeIteratorV1_12.java
+++ b/src/main/java/haveric/recipeManager/tools/RecipeIteratorV1_12.java
@@ -107,6 +107,7 @@ public class RecipeIteratorV1_12 implements Iterator<Recipe> {
         }
         switch (removeFrom) {
         case RECIPES:
+            //MessageSender.getInstance().info("NMS for 1.12 removing recipe " + removeRecipe);
             try {
                 Field keyF = removeRecipe.getClass().getField("key");
                 MinecraftKey key = (MinecraftKey) keyF.get(removeRecipe);
@@ -164,6 +165,7 @@ public class RecipeIteratorV1_12 implements Iterator<Recipe> {
         case RECIPES:
             // A _key_ assumption with replace is that the original items and shape is _unchanged_. Only result is overridden.
             try {
+                //MessageSender.getInstance().info("NMS for 1.12 replacing recipe " + recipe.getName());
                 Field keyF = removeRecipe.getClass().getField("key");
                 MinecraftKey key = (MinecraftKey) keyF.get(removeRecipe);
                 if (removeRecipe instanceof ShapedRecipes && recipe instanceof CraftRecipe) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: RecipeManager
 description: Add, edit or remove recipes and fuels
-version: 2.13.0
-authors: [haveric, Digi]
+version: 2.13.1
+authors: [haveric, Digi, ProgrammerDan]
 website: http://dev.bukkit.org/server-mods/recipemanager/
 dev-url: http://dev.bukkit.org/server-mods/recipemanager/
 main: haveric.recipeManager.RecipeManager


### PR DESCRIPTION
The matcher was flawed, this has been corrected, it now replicates roughly the methodology of the underlying minecraft approach.

I added some debug statements into the v1.12 tooling, but have it commented out for now. Should assist if more issues appear in the future.

Should be tested more before release, but in small scale tests had no new regressions, only corrected matching for shapeless recipes.