### PR TITLE
Update Minecraft wiki refereneces

### DIFF
--- a/RecipeManager-base/src/main/java/haveric/recipeManager/Files.java
+++ b/RecipeManager-base/src/main/java/haveric/recipeManager/Files.java
@@ -677,7 +677,7 @@ public class Files {
 
         s.append(NL).append("</pre></div><div class='doc-section__group'><pre>");
         addNameIndexHeading(s, "material", "MATERIAL LIST", "Material", "Material");
-        s.append("Data/damage/durability values are listed at <a href='https://minecraft.fandom.com/wiki/Data_values#Data'>Minecraft Fandom / Data Values</a>");
+        s.append("Data/damage/durability values are listed at <a href='https://minecraft.wiki/w/Java_Edition_data_values'>Minecraft Wiki / Data Values</a>");
         s.append(NL);
         if (Version.has1_12Support()) {
             s.append(NL).append(String.format("<b> %-34s %-34s %-5s  %-14s  %-5s %-4s</b>", "Name", "Alias", "Stack", "Max durability", "Block", "Item"));
@@ -739,7 +739,7 @@ public class Files {
         s.append(NL);
         s.append(NL).append("NOTE: The duration is compensated when setting potions in flags, so when using 2 seconds it will last 2 seconds regardless of effect type.");
         s.append(NL);
-        s.append(NL).append("More about potions, effects and custom effects: <a href=\"https://minecraft.gamepedia.com/Status_effect\">https://minecraft.gamepedia.com/Status_effect</a>");
+        s.append(NL).append("More about potions, effects and custom effects: <a href=\"https://minecraft.wiki/w/Status_effect\">https://minecraft.wiki/w/Status_effect</a>");
 
         s.append(NL).append("</pre></div><div class='doc-section__group'><pre>");
         addNameIndexHeading(s, "potiontype", "POTION TYPE LIST", "potion/PotionType", "PotionType");

--- a/RecipeManager-base/src/main/java/haveric/recipeManager/Files.java
+++ b/RecipeManager-base/src/main/java/haveric/recipeManager/Files.java
@@ -739,7 +739,7 @@ public class Files {
         s.append(NL);
         s.append(NL).append("NOTE: The duration is compensated when setting potions in flags, so when using 2 seconds it will last 2 seconds regardless of effect type.");
         s.append(NL);
-        s.append(NL).append("More about potions, effects and custom effects: <a href=\"https://minecraft.wiki/w/Status_effect\">https://minecraft.wiki/w/Status_effect</a>");
+        s.append(NL).append("More about potions, effects and custom effects: <a href=\"https://minecraft.wiki/w/Effect\">https://minecraft.wiki/w/Effect</a>");
 
         s.append(NL).append("</pre></div><div class='doc-section__group'><pre>");
         addNameIndexHeading(s, "potiontype", "POTION TYPE LIST", "potion/PotionType", "PotionType");

--- a/RecipeManager-base/src/main/java/haveric/recipeManager/flag/flags/any/FlagSetBlock.java
+++ b/RecipeManager-base/src/main/java/haveric/recipeManager/flag/flags/any/FlagSetBlock.java
@@ -33,7 +33,7 @@ public class FlagSetBlock extends Flag {
             "Using this flag more than once will overwrite the previous flag.",
             "",
             "Replace '&lt;block material&gt;' with a block material (not item!), see " + Files.getNameIndexHashLink("material"),
-            "Optionally you can define a data value which defines its skin, direction and other stuff, see <a href='https://minecraft.fandom.com/wiki/Data_values#Data'>Minecraft Fandom / Data Values</a>",
+            "Optionally you can define a data value which defines its skin, direction and other stuff, see <a href='https://minecraft.wiki/w/Java_Edition_data_values'>Minecraft Wiki / Data Values</a>",
             "You can also use aliases for materials and data values too.",
             "",
             "Additionally you can define a set of arguments separated by | character:",

--- a/docs/docs/latest/name index.html
+++ b/docs/docs/latest/name index.html
@@ -1883,7 +1883,7 @@ Data/damage/durability values are listed at <a href='https://minecraft.wiki/w/Ja
 
 NOTE: The duration is compensated when setting potions in flags, so when using 2 seconds it will last 2 seconds regardless of effect type.
 
-More about potions, effects and custom effects: <a href="https://minecraft.wiki/w/Status_effect">https://minecraft.wiki/w/Status_effect</a>
+More about potions, effects and custom effects: <a href="https://minecraft.wiki/w/Effect">https://minecraft.wiki/w/Effect</a>
 </pre></div><div class='doc-section__group'><pre><a id='potiontype'></a><a href='#contents' class='back-to-top'>^ Contents</a><h3>POTION TYPE LIST</h3><a href='https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionType.html'>BukkitAPI / PotionType</a>
 
 <b> ID    Name                     Instant ?  Max level  Effect type     </b>

--- a/docs/docs/latest/name index.html
+++ b/docs/docs/latest/name index.html
@@ -363,7 +363,7 @@ If you want to update this file just delete it and use '<i>rmreload</i>' or star
  HORSE_JUMP_STRENGTH
  ZOMBIE_SPAWN_REINFORCEMENTS
 </pre></div><div class='doc-section__group'><pre><a id='material'></a><a href='#contents' class='back-to-top'>^ Contents</a><h3>MATERIAL LIST</h3><a href='https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html'>BukkitAPI / Material</a>
-Data/damage/durability values are listed at <a href='https://minecraft.fandom.com/wiki/Data_values#Data'>Minecraft Fandom / Data Values</a>
+Data/damage/durability values are listed at <a href='https://minecraft.wiki/w/Java_Edition_data_values'>Minecraft Wiki / Data Values</a>
 
 <b> Name                               Alias                              Stack  Max durability  Block Item</b>
  AIR                                Air                                0                       Block Item
@@ -1883,7 +1883,7 @@ Data/damage/durability values are listed at <a href='https://minecraft.fandom.co
 
 NOTE: The duration is compensated when setting potions in flags, so when using 2 seconds it will last 2 seconds regardless of effect type.
 
-More about potions, effects and custom effects: <a href="https://minecraft.gamepedia.com/Status_effect">https://minecraft.gamepedia.com/Status_effect</a>
+More about potions, effects and custom effects: <a href="https://minecraft.wiki/w/Status_effect">https://minecraft.wiki/w/Status_effect</a>
 </pre></div><div class='doc-section__group'><pre><a id='potiontype'></a><a href='#contents' class='back-to-top'>^ Contents</a><h3>POTION TYPE LIST</h3><a href='https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionType.html'>BukkitAPI / PotionType</a>
 
 <b> ID    Name                     Instant ?  Max level  Effect type     </b>

--- a/docs/docs/latest/recipe flags.html
+++ b/docs/docs/latest/recipe flags.html
@@ -2521,7 +2521,7 @@ title: Recipe Flags
     Using this flag more than once will overwrite the previous flag.
 
     Replace '&lt;block material&gt;' with a block material (not item!), see <a href='name index.html#material'>name index.html#material</a>
-    Optionally you can define a data value which defines its skin, direction and other stuff, see <a href='https://minecraft.fandom.com/wiki/Data_values#Data'>Minecraft Fandom / Data Values</a>
+    Optionally you can define a data value which defines its skin, direction and other stuff, see <a href='https://minecraft.wiki/w/Java_Edition_data_values'>Minecraft Wiki / Data Values</a>
     You can also use aliases for materials and data values too.
 
     Additionally you can define a set of arguments separated by | character:


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all references accordingly.