### PR TITLE
fix detecting Composter recipe result BONE_MEAL as vanilla result

### DIFF
--- a/RecipeManager-base/src/main/java/haveric/recipeManager/recipes/compost/CompostEvents.java
+++ b/RecipeManager-base/src/main/java/haveric/recipeManager/recipes/compost/CompostEvents.java
@@ -203,7 +203,7 @@ public class CompostEvents extends BaseRecipeEvents {
                     if (!recipe.isMultiResult()) {
                         ItemResult recipeResult = recipe.getFirstResult();
 
-                        if (recipeResult.hashCode() == CompostRecipe.VANILLA_ITEM_RESULT.hashCode()) {
+                        if (recipeResult.getItemStack().hashCode() == CompostRecipe.VANILLA_ITEM_RESULT.getItemStack().hashCode()) {
                             matchesVanillaResult = true;
                         }
                     }


### PR DESCRIPTION
Correctly detect the BONE_MEAL as "vanilla result" from composter recipes. Previously, the result was not recognised and an error was sent to the player instead.

Better solution might be to rewrite ItemResult.hashCode() method, but I'm not familiar enough with the codebase to assess the full impact of such a change.